### PR TITLE
ci: update actions and pin node to lts for wrangler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,11 @@ jobs:
     name: Lint, Types & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.bun/install/cache
@@ -40,11 +40,11 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.bun/install/cache
@@ -76,7 +76,13 @@ jobs:
           name: www2-dist
           path: apps/www2/dist
 
-      - uses: cloudflare/wrangler-action@v3
+      # Wrangler runs on the runner's Node — pin it to the active LTS instead
+      # of whatever ubuntu-latest happens to ship.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: lts/*
+
+      - uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
Updates the CI workflow to current action majors and pins Node for the deploy step:

- `actions/checkout`: v6 → v7
- `actions/cache`: v5 → v6
- `cloudflare/wrangler-action`: v3 → v4 — installs Wrangler v4 by default, matching the repo's `wrangler` 4.114.0 dev dependency; `pages deploy` syntax is unchanged
- `actions/setup-node@v7` with `node-version: lts/*` before the Wrangler step, so deploys run on the active Node LTS instead of whatever `ubuntu-latest` ships

`upload-artifact` (v7), `download-artifact` (v8), and `setup-bun` (v2) are already on their latest majors.