### PR TITLE
fix(www2): silence the Safari view-transition unhandled rejection

### DIFF
--- a/apps/www2/src/layouts/BaseLayout.astro
+++ b/apps/www2/src/layouts/BaseLayout.astro
@@ -116,11 +116,15 @@ const ogImageType = ogImageUrl.endsWith('.png') ? 'image/png' : 'image/jpeg'
           if (!vt) return
           // Per spec skipTransition() rejects `ready` with an AbortError, and Astro's
           // router only ever attaches handlers to updateCallbackDone and finished.
-          // Without a catch here that rejection reaches the console as an unhandled
-          // promise on every single navigation. Claiming it changes nothing else:
-          // this derived promise is discarded, and the swap runs off the two
-          // promises Astro does await.
-          vt.ready?.catch(() => {})
+          // Without a handler here that rejection reaches the console as an unhandled
+          // promise on every single navigation. Claiming it changes nothing else: this
+          // derived promise is discarded, and the swap runs off the two promises Astro
+          // does await. Anything that is not the AbortError we just asked for is a real
+          // failure, so it still gets reported rather than swallowed — logged rather
+          // than rethrown, since rethrowing would recreate the unhandled rejection.
+          void vt.ready?.catch((err) => {
+            if (err?.name !== 'AbortError') console.error('[view-transition]', err)
+          })
           vt.skipTransition()
         })
       }

--- a/apps/www2/src/layouts/BaseLayout.astro
+++ b/apps/www2/src/layouts/BaseLayout.astro
@@ -112,7 +112,16 @@ const ogImageType = ogImageUrl.endsWith('.png') ? 'image/png' : 'image/jpeg'
     <script is:inline>
       if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent)) {
         document.addEventListener('astro:before-swap', (e) => {
-          e.viewTransition?.skipTransition()
+          const vt = e.viewTransition
+          if (!vt) return
+          // Per spec skipTransition() rejects `ready` with an AbortError, and Astro's
+          // router only ever attaches handlers to updateCallbackDone and finished.
+          // Without a catch here that rejection reaches the console as an unhandled
+          // promise on every single navigation. Claiming it changes nothing else:
+          // this derived promise is discarded, and the swap runs off the two
+          // promises Astro does await.
+          vt.ready?.catch(() => {})
+          vt.skipTransition()
         })
       }
     </script>


### PR DESCRIPTION
## Symptom

On Safari, every client-router navigation logs:

```
Unhandled Promise Rejection: AbortError: Skipping view transition because skipTransition() was called.
```

Nothing breaks — the swap completes — but the console fills up.

## Cause

`BaseLayout.astro` skips view transitions on Safari to avoid snapshot stutter:

```js
document.addEventListener('astro:before-swap', (e) => {
  e.viewTransition?.skipTransition()
})
```

Per the [View Transitions spec](https://drafts.csswg.org/css-view-transitions-1/#dom-viewtransition-skiptransition), `skipTransition()` rejects the transition's `ready` promise with an `AbortError`. Astro's router (7.1.3) attaches handlers to `updateCallbackDone` and `finished` but **never to `.ready`** — `grep -rn "\.ready" node_modules/astro/dist/transitions/*.js` returns nothing outside the object literal that defines it. So the rejection has no observer anywhere and surfaces as unhandled.

It only fires in Safari because that's the only branch that calls `skipTransition()`.

## Fix

Claim `ready` with a no-op catch before skipping. The derived promise is discarded; the swap still runs off the two promises Astro does await, so no genuine error is hidden.

## Verification

Reproduced in WebKit — the same engine as Safari — via `Bun.WebView`, driving a real ClientRouter navigation on the built site with an `unhandledrejection` listener attached:

| Variant | Unhandled rejections |
| --- | --- |
| A — `skipTransition()`, no catch (current `main`) | `AbortError: Skipping view transition because skipTransition() was called.` |
| B — catch, then `skipTransition()` (this PR) | none |

Note the site's own Safari UA test does not match `Bun.WebView`'s user agent, so the A/B attaches the handler explicitly to isolate the mechanism rather than relying on the UA branch.