### PR TITLE
feat(www2): restore wide OG cards, add square ones for feeds

### DIFF
--- a/apps/www2/src/pages/og/square/[locale]/[...page].png.ts
+++ b/apps/www2/src/pages/og/square/[locale]/[...page].png.ts
@@ -1,0 +1,36 @@
+import type { APIRoute } from 'astro'
+
+import { getPageCopy } from '@/utils/feed'
+import { availableLocales, type LocaleCode } from '@/utils/i18n'
+import {
+  OG_SIZE_SQUARE,
+  OG_STYLE,
+  type PageOgKey,
+  pageOgIcons,
+  pageOgKeys,
+  pageOgSlugs,
+  renderOgImage,
+} from '@/utils/ogImage'
+
+/** The wide card's twin on a square canvas — see `OG_SQUARE` for why feeds get one. */
+export function getStaticPaths() {
+  return pageOgKeys.flatMap((key) =>
+    availableLocales.map((locale) => ({
+      params: { locale, page: pageOgSlugs[key] },
+      props: { key },
+    })),
+  )
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  const { locale } = params as { locale: LocaleCode }
+  const { key } = props as { key: PageOgKey }
+
+  const copy = getPageCopy(locale)[key]
+  const png = await renderOgImage({ ...copy, icon: pageOgIcons[key] }, OG_STYLE, OG_SIZE_SQUARE)
+
+  // Static build — see the wide card route on why caching lives in _headers.
+  return new Response(png, {
+    headers: { 'Content-Type': 'image/png' },
+  })
+}

--- a/apps/www2/src/pages/og/square/[locale]/projects/[slug].png.ts
+++ b/apps/www2/src/pages/og/square/[locale]/projects/[slug].png.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from 'astro'
+
+import { projects } from '@/data/projects'
+import { availableLocales, type LocaleCode } from '@/utils/i18n'
+import { OG_SIZE_SQUARE, OG_STYLE, projectOgCard, renderOgImage } from '@/utils/ogImage'
+
+/** The wide card's twin on a square canvas — see `OG_SQUARE` for why feeds get one. */
+export function getStaticPaths() {
+  return projects.flatMap((project) =>
+    availableLocales.map((locale) => ({
+      params: { locale, slug: project.slug },
+      props: { project },
+    })),
+  )
+}
+
+export const GET: APIRoute = async ({ params, props }) => {
+  const { locale } = params as { locale: LocaleCode }
+  const { project } = props as { project: (typeof projects)[number] }
+
+  const png = await renderOgImage(projectOgCard(project, locale), OG_STYLE, OG_SIZE_SQUARE)
+
+  // Static build — see the wide card route on why caching lives in _headers.
+  return new Response(png, {
+    headers: { 'Content-Type': 'image/png' },
+  })
+}

--- a/apps/www2/src/utils/feed.ts
+++ b/apps/www2/src/utils/feed.ts
@@ -5,7 +5,7 @@ import { getFeedProjects } from '@/data/projects'
 
 import { getT } from './getT'
 import type { LocaleCode } from './i18n'
-import { type PageOgKey, pageOgImagePath, projectOgImagePath } from './ogImage'
+import { OG_SQUARE, type PageOgKey, pageOgSquarePath, projectOgSquarePath } from './ogImage'
 
 export interface FeedItem {
   /** Site-root-relative path. */
@@ -39,7 +39,10 @@ export function getPageCopy(
 ): Record<PageOgKey, { title: string; description: string }> {
   const t = getT(locale)
   return {
-    cv: { title: `CV — ${t.fullName}`, description: t.meta.descriptionShort },
+    // The full stop is added here rather than in the string itself: every other
+    // card ends on one, but `descriptionShort` is also the navbar tagline and the
+    // CV page subtitle, where a sentence-ending period would read as a typo.
+    cv: { title: `CV — ${t.fullName}`, description: `${t.meta.descriptionShort}.` },
     contact: { title: t.contact.title, description: t.contact.subtitle },
     openSource: { title: t.builtWithTitle, description: t.builtWithDescription },
     projects: { title: t.projects.title, description: t.projects.description },
@@ -59,7 +62,7 @@ export function getFeedItems(locale: LocaleCode): FeedItem[] {
     path: `/${locale}/projects/${project.slug}`,
     title: project.title[locale],
     description: project.description[locale],
-    image: `${BASE_URL}${projectOgImagePath(project.slug, locale)}`,
+    image: `${BASE_URL}${projectOgSquarePath(project.slug, locale)}`,
     published: new Date(project.publishedAt),
     ...(project.updatedAt && { updated: new Date(project.updatedAt) }),
     tags: project.tags,
@@ -70,7 +73,7 @@ export function getFeedItems(locale: LocaleCode): FeedItem[] {
   const pages: FeedItem[] = feedPages.map((page) => ({
     ...pageCopy[page.key],
     path: `/${locale}${page.path}`,
-    image: `${BASE_URL}${pageOgImagePath(page.key, locale)}`,
+    image: `${BASE_URL}${pageOgSquarePath(page.key, locale)}`,
     published: new Date(page.publishedAt),
     ...(page.updatedAt && { updated: new Date(page.updatedAt) }),
   }))
@@ -92,7 +95,7 @@ function escapeHtml(text: string): string {
 /** Item body shared by both formats: the card image, then the summary. */
 export function feedItemHtml(item: FeedItem): string {
   const image = item.image
-    ? `<p><img src="${item.image}" alt="${escapeHtml(item.title)}" width="1200" height="630" /></p>`
+    ? `<p><img src="${item.image}" alt="${escapeHtml(item.title)}" width="${OG_SQUARE}" height="${OG_SQUARE}" /></p>`
     : ''
   return `${image}<p>${escapeHtml(item.description)}</p>`
 }

--- a/apps/www2/src/utils/feed.ts
+++ b/apps/www2/src/utils/feed.ts
@@ -29,6 +29,11 @@ export function feedItemDate(item: FeedItem): Date {
   return item.updated ?? item.published
 }
 
+/** Adds a full stop unless the copy already closes itself, in either script. */
+function endSentence(text: string): string {
+  return /[.!?…:;]$/.test(text.trimEnd()) ? text : `${text}.`
+}
+
 /**
  * Titles and descriptions come from the translations the pages themselves use, and
  * are shared with the generated cards so a page, its feed entry and its social image
@@ -42,7 +47,7 @@ export function getPageCopy(
     // The full stop is added here rather than in the string itself: every other
     // card ends on one, but `descriptionShort` is also the navbar tagline and the
     // CV page subtitle, where a sentence-ending period would read as a typo.
-    cv: { title: `CV — ${t.fullName}`, description: `${t.meta.descriptionShort}.` },
+    cv: { title: `CV — ${t.fullName}`, description: endSentence(t.meta.descriptionShort) },
     contact: { title: t.contact.title, description: t.contact.subtitle },
     openSource: { title: t.builtWithTitle, description: t.builtWithDescription },
     projects: { title: t.projects.title, description: t.projects.description },

--- a/apps/www2/src/utils/ogImage.ts
+++ b/apps/www2/src/utils/ogImage.ts
@@ -9,25 +9,25 @@ export const OG_WIDTH = 1200
 export const OG_HEIGHT = 630
 
 /**
- * Feed readers and chat apps rarely show the full 1.91:1 card — Reeder, among
- * others, thumbnails it as a square, which keeps only the middle `OG_HEIGHT` of
- * width and drops the rest from each side. Everything that carries meaning lives
- * inside that square, so a crop loses only background.
+ * Feed readers thumbnail a square rather than showing the 1.91:1 frame — Reeder
+ * keeps the middle `OG_HEIGHT` of width and drops the rest, which once beheaded
+ * `countries-list` into "tries-list" and lost the icon and domain with it.
+ *
+ * The fix is not to lay the card out inside that centre square: doing so spends
+ * the outer thirds of a wide preview on background, which reads as an almost
+ * empty image with a caption floating in the middle. Instead the same edge-to-edge
+ * layout is rendered onto a second, genuinely square canvas, and feeds point at
+ * that one. Nothing is cropped, and neither consumer pays for the other.
  */
-const SQUARE_LEFT = (OG_WIDTH - OG_HEIGHT) / 2
+export const OG_SQUARE = 1200
 
-/** The rule sits just inside the square's edge, so a crop cannot shave it off. */
-const RULE_INSET = 14
-const RULE_WIDTH = 6
-/** The icon hangs between rule and text with the same air on either side. */
-const ICON_GAP = 26
-/** Right margin inside the square, so text never runs to the crop line. */
-const SAFE_MARGIN = 24
-
-/** Text width left inside the square once the rule and hanging icon take their room. */
-function contentWidth(iconSize: number): number {
-  return OG_HEIGHT - RULE_INSET - RULE_WIDTH - ICON_GAP * 2 - iconSize - SAFE_MARGIN
+export interface OgSize {
+  width: number
+  height: number
 }
+
+export const OG_SIZE_WIDE: OgSize = { width: OG_WIDTH, height: OG_HEIGHT }
+export const OG_SIZE_SQUARE: OgSize = { width: OG_SQUARE, height: OG_SQUARE }
 
 /**
  * Hoisted so the whole build shares one font fetch. `render` accepts a promise
@@ -154,63 +154,75 @@ export interface OgCard {
   tags?: string[]
 }
 
-export function buildOgHtml(card: OgCard, style: OgStyle = OG_STYLE): string {
+export function buildOgHtml(
+  card: OgCard,
+  style: OgStyle = OG_STYLE,
+  size: OgSize = OG_SIZE_WIDE,
+): string {
   const palette = palettes[style.theme]
   const background = style.background === 'plain' ? palette.plain : palette.gradient
 
   const title = sanitizeText(card.title)
-  const statusLabel = card.badge
-  const cardTags = (card.tags ?? []).slice(0, 4)
-
   const description = sanitizeText(clamp(card.description, OG_DESCRIPTION_LIMIT))
+  const statusLabel = card.badge
 
-  // The badge leads the pill row rather than sitting above the title: the icon hangs
-  // beside whatever comes first, and that should be the title.
-  const badge = statusLabel
-    ? `<div style="display:flex;flex-shrink:0;white-space:nowrap;padding:7px 16px;border-radius:999px;background:${palette.tagBg};color:${palette.accent};font-size:20px;font-weight:700;letter-spacing:1px">${sanitizeText(statusLabel)}</div>`
-    : ''
-
-  const tags = cardTags
+  const tags = (card.tags ?? [])
+    .slice(0, 5)
     .map(
       (tag) =>
         // `white-space:nowrap` matters: a hyphen is a break opportunity, so tags like
         // `react-query` were measured as two lines and rendered a taller pill.
-        `<div style="display:flex;flex-shrink:0;white-space:nowrap;padding:7px 16px;border-radius:999px;background:${palette.tagBg};color:${palette.tagText};font-size:20px">${sanitizeText(tag)}</div>`,
+        `<div style="display:flex;flex-shrink:0;white-space:nowrap;padding:8px 18px;border-radius:999px;background:${palette.tagBg};color:${palette.tagText};font-size:24px">${sanitizeText(tag)}</div>`,
     )
     .join('')
 
-  // The icon matches the title's height, so the two read as one line of masthead.
-  // Kept modest so a longer title still lands on one line inside the square.
-  const titleSize = title.length > 18 ? 42 : 48
-
-  // Rule, icon and text are siblings of one stretch row rather than nested boxes:
-  // the renderer measures a nested column short of its trailing children, which left
-  // the rule sized to the title and description alone and the text sitting lower.
-  return `<div style="width:100%;height:100%;display:flex;align-items:center;background:${background};padding-left:${SQUARE_LEFT + RULE_INSET}px;font-family:Inter">
-  <div style="display:flex;align-items:stretch">
-    <div style="display:flex;width:${RULE_WIDTH}px;background:${palette.accent};border-radius:999px"></div>
-
-    <img style="margin-top:${Math.round(titleSize * 0.16)}px;margin-left:${ICON_GAP}px;margin-right:${ICON_GAP}px" src="${iconDataUri(card.icon, palette.accent)}" width="${titleSize}" height="${titleSize}" />
-
-    <div style="display:flex;flex-direction:column;max-width:${contentWidth(titleSize)}px">
-      <div style="display:flex;flex-direction:column;font-size:${titleSize}px;font-weight:700;color:${palette.title};line-height:1.15">${title}</div>
-      <div style="display:flex;flex-direction:column;margin-top:14px;font-size:26px;color:${palette.body};line-height:1.4">${description}</div>
-
-      ${badge || tags ? `<div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin-top:14px">${badge}${tags}</div>` : ''}
-
-      <div style="display:flex;margin-top:14px;font-size:23px;color:${palette.muted}">dmythro.com</div>
+  const masthead = `<div style="display:flex;align-items:center;justify-content:space-between">
+    <div style="display:flex;align-items:center;gap:16px">
+      <img src="${iconDataUri(card.icon, palette.accent)}" width="52" height="52" />
+      ${
+        statusLabel
+          ? `<div style="display:flex;flex-shrink:0;white-space:nowrap;padding:6px 16px;border-radius:999px;background:${palette.tagBg};color:${palette.accent};font-size:24px;font-weight:700;letter-spacing:1px">${sanitizeText(statusLabel)}</div>`
+          : ''
+      }
     </div>
-  </div>
+    <div style="font-size:26px;color:${palette.muted}">dmythro.com</div>
+  </div>`
+
+  const copy = `<div style="display:flex;flex-direction:column;gap:24px">
+    <div style="display:flex;flex-direction:column;font-size:${title.length > 18 ? 66 : 78}px;font-weight:700;color:${palette.title};line-height:1.1">${title}</div>
+    <div style="display:flex;flex-direction:column;font-size:32px;color:${palette.body};line-height:1.4">${description}</div>
+  </div>`
+
+  const tagRow = tags
+    ? `<div style="display:flex;flex-wrap:wrap;align-items:center;gap:12px">${tags}</div>`
+    : ''
+
+  // Masthead at the top, copy and tags together at the foot. On the wide canvas
+  // the three bands sit close enough that spacing them apart reads as one
+  // composition; on the square there is 570px more height, and spreading the same
+  // three bands over it strands the copy alone in the middle. Grouping the copy
+  // with its tags keeps the card looking deliberate at either shape.
+  // `>=`, not `>`: a square is exactly as tall as it is wide, and the whole point
+  // of this branch is the square.
+  const body =
+    size.height >= size.width
+      ? `<div style="display:flex;flex-direction:column;gap:56px">${copy}${tagRow}</div>`
+      : `${copy}${tagRow}`
+
+  return `<div style="width:100%;height:100%;display:flex;flex-direction:column;justify-content:space-between;background:${background};padding:72px;font-family:Inter">
+  ${masthead}
+  ${body}
 </div>`
 }
 
 export async function renderOgImage(
   card: OgCard,
   style: OgStyle = OG_STYLE,
+  size: OgSize = OG_SIZE_WIDE,
 ): Promise<Uint8Array<ArrayBuffer>> {
-  const png = await render(buildOgHtml(card, style), {
-    width: OG_WIDTH,
-    height: OG_HEIGHT,
+  const png = await render(buildOgHtml(card, style, size), {
+    width: size.width,
+    height: size.height,
     fonts,
   })
 
@@ -235,6 +247,11 @@ export function projectOgCard(project: Project, locale: LocaleCode): OgCard {
 /** Site-root-relative path of a project's generated OG image. */
 export function projectOgImagePath(slug: string, locale: LocaleCode): string {
   return `/og/${locale}/projects/${slug}.png`
+}
+
+/** The same card on a square canvas, for feed readers that thumbnail one. */
+export function projectOgSquarePath(slug: string, locale: LocaleCode): string {
+  return `/og/square/${locale}/projects/${slug}.png`
 }
 
 /**
@@ -273,4 +290,9 @@ export const pageOgSlugs: Record<PageOgKey, string> = {
 /** Site-root-relative path of a standing page's generated OG image. */
 export function pageOgImagePath(key: PageOgKey, locale: LocaleCode): string {
   return `/og/${locale}/${pageOgSlugs[key]}.png`
+}
+
+/** The same card on a square canvas, for feed readers that thumbnail one. */
+export function pageOgSquarePath(key: PageOgKey, locale: LocaleCode): string {
+  return `/og/square/${locale}/${pageOgSlugs[key]}.png`
 }

--- a/apps/www2/src/utils/ogImage.ts
+++ b/apps/www2/src/utils/ogImage.ts
@@ -206,7 +206,10 @@ export function buildOgHtml(card: OgCard, style: OgStyle = OG_STYLE): string {
   // children, so a card with no tags has only two of them and the copy drops to
   // the floor — which is what the standing pages were doing. Growing the middle
   // makes the same rule hold whether or not there are tags, and at either shape.
-  return `<div style="width:100%;height:100%;display:flex;flex-direction:column;justify-content:space-between;background:${background};padding:72px;font-family:Inter">
+  // `overflow:hidden` is a backstop, not a layout tool: every card clears the
+  // edges by 70px today, but a long title over a long description over two rows
+  // of tags would out-measure the wide canvas, and clipping beats spilling.
+  return `<div style="width:100%;height:100%;overflow:hidden;display:flex;flex-direction:column;justify-content:space-between;background:${background};padding:72px;font-family:Inter">
   ${masthead}
   <div style="flex-grow:1;display:flex;flex-direction:column;justify-content:center">${copy}</div>
   ${tagRow}

--- a/apps/www2/src/utils/ogImage.ts
+++ b/apps/www2/src/utils/ogImage.ts
@@ -154,11 +154,7 @@ export interface OgCard {
   tags?: string[]
 }
 
-export function buildOgHtml(
-  card: OgCard,
-  style: OgStyle = OG_STYLE,
-  size: OgSize = OG_SIZE_WIDE,
-): string {
+export function buildOgHtml(card: OgCard, style: OgStyle = OG_STYLE): string {
   const palette = palettes[style.theme]
   const background = style.background === 'plain' ? palette.plain : palette.gradient
 
@@ -204,14 +200,16 @@ export function buildOgHtml(
   // with its tags keeps the card looking deliberate at either shape.
   // `>=`, not `>`: a square is exactly as tall as it is wide, and the whole point
   // of this branch is the square.
-  const body =
-    size.height >= size.width
-      ? `<div style="display:flex;flex-direction:column;gap:56px">${copy}${tagRow}</div>`
-      : `${copy}${tagRow}`
-
+  //
+  // Masthead and tags anchor the top and bottom corners; the copy claims whatever
+  // is left and centres in it. `space-between` alone is not enough: it distributes
+  // children, so a card with no tags has only two of them and the copy drops to
+  // the floor — which is what the standing pages were doing. Growing the middle
+  // makes the same rule hold whether or not there are tags, and at either shape.
   return `<div style="width:100%;height:100%;display:flex;flex-direction:column;justify-content:space-between;background:${background};padding:72px;font-family:Inter">
   ${masthead}
-  ${body}
+  <div style="flex-grow:1;display:flex;flex-direction:column;justify-content:center">${copy}</div>
+  ${tagRow}
 </div>`
 }
 
@@ -220,7 +218,7 @@ export async function renderOgImage(
   style: OgStyle = OG_STYLE,
   size: OgSize = OG_SIZE_WIDE,
 ): Promise<Uint8Array<ArrayBuffer>> {
-  const png = await render(buildOgHtml(card, style, size), {
+  const png = await render(buildOgHtml(card, style), {
     width: size.width,
     height: size.height,
     fonts,


### PR DESCRIPTION
## Why

The cards were rebuilt around a centre square so feed readers could crop them without beheading the title — Reeder keeps the middle 630px and drops the rest, which once turned `countries-list` into "tries-list" and cut the icon and domain entirely.

That worked, but the wide preview paid for it. Laying everything inside the middle 630px leaves the outer thirds as bare background, so a chat preview reads as an almost empty image with a caption floating in the middle.

## What

Restore the **edge-to-edge layout** for `og:image` — masthead with icon and domain, large title, description, tags along the foot — and give feeds a **second render of the same card on a genuinely square 1200×1200 canvas**. Nothing is cropped in either place, and neither consumer pays for the other.

| | wide 1200×630 | square 1200×1200 |
| --- | --- | --- |
| used by | `og:image` on every page | RSS + JSON Feed `image` |
| count | 26 | 26 |
| top / bottom margin | 74px / 82px | 74px / 82px |

Corners are anchored identically at both shapes; the square simply has more air between them.

## A bug this surfaced

`justify-content: space-between` *distributes* children, so a card with no tags had only two of them and the copy fell to the floor. Every standing page — cv, contact, open-source, projects — was rendering that way, on both shapes.

Fixed by anchoring the masthead and tags to the corners and letting the copy claim what is left, centring in it. One rule now covers all four cases:

| case | before (above / below copy) | after |
| --- | --- | --- |
| wide, tags | 107 / 112 | 107 / 112 |
| wide, no tags | **307 / 78** | 161 / 224 |
| square, tags | — | 392 / 397 |
| square, no tags | — | 446 / 509 |

## Carried over from the square-safe version

Those changes were not all layout — the useful parts stay:

- `white-space:nowrap` + `flex-shrink:0` on tags, so hyphenated ones like `react-query` stay one line at fixed height
- `display:flex;flex-direction:column` on title and description — the renderer measures nested columns short without it
- Sentence-aware clamp and the shared `OG_DESCRIPTION_LIMIT`, still asserted by `og-cards.test.ts`
- `flex-wrap` on the tag row, which the original layout lacked

## Also

- CV card gains the full stop every other card already ended on. Added in `getPageCopy` rather than in `descriptionShort`, since that same string is the navbar tagline and the CV page subtitle — and only when the copy does not already close itself.
- `overflow:hidden` on the card. Every one of the 52 clears its edges by 70px today, but a long title over a long description over two rows of tags out-measures the wide frame.

## Verified

All 52 generated cards measured programmatically: no ink touches any edge, tightest margin 70px. Lint, types, 37 tests and the build are green. Reviewed locally with CodeRabbit CLI; both findings addressed above.